### PR TITLE
Add Drive Assist Features

### DIFF
--- a/imgui.ini
+++ b/imgui.ini
@@ -35,7 +35,7 @@ Collapsed=0
 
 [Window][###Joysticks]
 Pos=227,487
-Size=796,166
+Size=796,211
 Collapsed=0
 
 [MainWindow][GLOBAL]
@@ -63,16 +63,37 @@ open=1
 [GlassStorage][NetworkTables###LiveWindow###.status]
 open=0
 
+[GlassStorage][NetworkTables###LiveWindow###DriveTrain]
+open=0
+
 [GlassStorage][NetworkTables###LiveWindow###ExampleSubsystem]
 open=1
 
 [GlassStorage][NetworkTables###LiveWindow###Ungrouped]
 open=1
 
+[GlassStorage][NetworkTables###LiveWindow###Ungrouped###DifferentialDrive[1]]
+open=0
+
+[GlassStorage][NetworkTables###LiveWindow###Ungrouped###PIDController[1]]
+open=0
+
+[GlassStorage][NetworkTables###LiveWindow###Ungrouped###PIDController[2]]
+open=0
+
 [GlassStorage][NetworkTables###LiveWindow###Ungrouped###PowerDistributionPanel[0]]
 open=0
 
 [GlassStorage][NetworkTables###LiveWindow###Ungrouped###Scheduler]
+open=0
+
+[GlassStorage][NetworkTables###LiveWindow###Ungrouped###Talon SRX [1]]
+open=0
+
+[GlassStorage][NetworkTables###LiveWindow###Ungrouped###Talon SRX [3]]
+open=0
+
+[GlassStorage][NetworkTables###LiveWindow###Ungrouped###navX-Sensor]
 open=0
 
 [GlassStorage][NetworkTables###LiveWindow###print]
@@ -87,10 +108,257 @@ open=0
 [GlassStorage][NetworkTables###Usage]
 open=0
 
+[GlassStorage][Other Devices###navX-Sensor[0]]
+name=
+name###open=0
+
+[Data Sources][Joystick[1] Button[4]]
+name=
+
 [Data Sources][Joystick[0] Button[7]]
 name=
 
+[Data Sources][NT:/SmartDashboard/DB/Button 0]
+name=
+
+[Data Sources][NT:/SmartDashboard/DB/Button 1]
+name=
+
+[Data Sources][NT:/SmartDashboard/DB/Button 2]
+name=
+
+[Data Sources][NT:/FMSInfo/FMSControlData]
+name=
+
+[Data Sources][NT:/SmartDashboard/DB/Button 3]
+name=
+
+[Data Sources][Joystick[1] Button[11]]
+name=
+
+[Data Sources][NT:/LiveWindow/.status/LW Enabled]
+name=
+
+[Data Sources][NT:/SmartDashboard/Joystick Y]
+name=
+
+[Data Sources][Joystick[0] Button[15]]
+name=
+
+[Data Sources][NT:/SmartDashboard/Joystick X]
+name=
+
+[Data Sources][NT:/LiveWindow/DriveTrain/.hasCommand]
+name=
+
+[Data Sources][Joystick[0] Axis[1]]
+name=
+
+[Data Sources][NT:/SmartDashboard/Battery Voltage]
+name=
+
+[Data Sources][NT:/Shuffleboard/Battery/Battery Voltage2]
+name=
+
+[Data Sources][Y Accel[0]]
+name=
+
+[Data Sources][navX-Sensor[0]-Connected]
+name=
+
+[Data Sources][Joystick[1] Axis[0]]
+name=
+
+[Data Sources][navX-Sensor[0]-CompassHeading]
+name=
+
+[Data Sources][navX-Sensor[0]-Pitch]
+name=
+
+[Data Sources][Joystick[1] Button[5]]
+name=
+
+[Data Sources][NT:/SmartDashboard/Joystick 2 X]
+name=
+
+[Data Sources][Joystick[0] Button[8]]
+name=
+
+[Data Sources][NT:/SmartDashboard/Joystick 2 Y]
+name=
+
+[Data Sources][NT:/Shuffleboard/Battery/Battery Voltage]
+name=
+
+[Data Sources][NT:/LiveWindow/print/.hasCommand]
+name=
+
+[Data Sources][NT:/LiveWindow/Ungrouped/PIDController[1]/d]
+name=
+
+[Data Sources][NT:/LiveWindow/Ungrouped/DifferentialDrive[1]/Right Motor Speed]
+name=
+
+[Data Sources][NT:/LiveWindow/Ungrouped/PIDController[1]/i]
+name=
+
+[Data Sources][NT:/LiveWindow/Ungrouped/PowerDistributionPanel[0]/Voltage]
+name=
+
+[Data Sources][Joystick[1] Button[12]]
+name=
+
+[Data Sources][NT:/Usage/Client/Dashboard/Writes]
+name=
+
+[Data Sources][Joystick[0] Button[16]]
+name=
+
+[Data Sources][NT:/LiveWindow/Ungrouped/PIDController[1]/p]
+name=
+
+[Data Sources][Joystick[0] Axis[2]]
+name=
+
+[Data Sources][Joystick[1] Axis[1]]
+name=
+
+[Data Sources][Z Accel[0]]
+name=
+
+[Data Sources][Joystick[0] Button[1]]
+name=
+
+[Data Sources][FMS:AutonomousMode]
+name=
+
+[Data Sources][NT:/SmartDashboard/E-Stop]
+name=
+
+[Data Sources][NT:/FMSInfo/MatchNumber]
+name=
+
+[Data Sources][Joystick[1] Button[6]]
+name=
+
+[Data Sources][Joystick[0] Button[9]]
+name=
+
+[Data Sources][navX-Sensor[0]-Rate]
+name=
+
+[Data Sources][FMS:AllianceStationID]
+name=
+
+[Data Sources][navX-Sensor[0]-LinearWorldAccelX]
+name=
+
+[Data Sources][navX-Sensor[0]-LinearWorldAccelY]
+name=
+
+[Data Sources][navX-Sensor[0]-LinearWorldAccelZ]
+name=
+
+[Data Sources][FMS:RobotEnabled]
+name=
+
+[Data Sources][Joystick[1] Button[13]]
+name=
+
+[Data Sources][Joystick[0] Button[17]]
+name=
+
+[Data Sources][NT:/Usage/Client/Dashboard/WritesPS]
+name=
+
+[Data Sources][NT:/SmartDashboard/Distance]
+name=
+
+[Data Sources][Joystick[0] Axis[3]]
+name=
+
+[Data Sources][Joystick[1] Axis[2]]
+name=
+
+[Data Sources][NT:/LiveWindow/Ungrouped/navX-Sensor/Value]
+name=
+
+[Data Sources][NT:/LiveWindow/DriveTrain/.hasDefault]
+name=
+
+[Data Sources][NT:/LiveWindow/Ungrouped/PIDController[1]/setpoint]
+name=
+
+[Data Sources][Joystick[0] Button[2]]
+name=
+
+[Data Sources][navX-Sensor[0]-FusedHeading]
+name=
+
+[Data Sources][NT:/Usage/Client/Dashboard/Reads]
+name=
+
+[Data Sources][Joystick[1] Button[7]]
+name=
+
+[Data Sources][FMS:TestMode]
+name=
+
+[Data Sources][NT:/Usage/Client/Dashboard/Updates]
+name=
+
+[Data Sources][FMS:EStop]
+name=
+
+[Data Sources][NT:/SmartDashboard/Field/.controllable]
+name=
+
+[Data Sources][Joystick[0] Button[10]]
+name=
+
+[Data Sources][NT:/LiveWindow/print/.hasDefault]
+name=
+
+[Data Sources][NT:/SmartDashboard/DB/Slider 0]
+name=
+
+[Data Sources][NT:/SmartDashboard/DB/Slider 1]
+name=
+
+[Data Sources][NT:/SmartDashboard/DB/Slider 2]
+name=
+
+[Data Sources][NT:/SmartDashboard/DB/Slider 3]
+name=
+
+[Data Sources][Joystick[1] Button[14]]
+name=
+
+[Data Sources][NT:/LiveWindow/Ungrouped/DifferentialDrive[1]/Left Motor Speed]
+name=
+
+[Data Sources][NT:/SmartDashboard/Total Energy]
+name=
+
+[Data Sources][Joystick[1] Axis[3]]
+name=
+
+[Data Sources][NT:/FMSInfo/IsRedAlliance]
+name=
+
+[Data Sources][NT:/LiveWindow/Ungrouped/Talon SRX [3]/Value]
+name=
+
+[Data Sources][Joystick[0] Button[3]]
+name=
+
 [Data Sources][NT:/Usage/Client/Dashboard/Kbps]
+name=
+
+[Data Sources][Joystick[1] Button[8]]
+name=
+
+[Data Sources][NT:/SmartDashboard/Forward Lock]
 name=
 
 [Data Sources][NT:/LiveWindow/Ungrouped/PowerDistributionPanel[0]/Chan0]
@@ -108,7 +376,7 @@ name=
 [Data Sources][NT:/LiveWindow/Ungrouped/PowerDistributionPanel[0]/Chan4]
 name=
 
-[Data Sources][NT:/FMSInfo/FMSControlData]
+[Data Sources][NT:/LiveWindow/Ungrouped/PowerDistributionPanel[0]/Chan5]
 name=
 
 [Data Sources][Joystick[0] Button[11]]
@@ -117,88 +385,64 @@ name=
 [Data Sources][NT:/LiveWindow/Ungrouped/PowerDistributionPanel[0]/Chan6]
 name=
 
-[Data Sources][NT:/LiveWindow/Ungrouped/PowerDistributionPanel[0]/Chan5]
-name=
-
-[Data Sources][NT:/LiveWindow/.status/LW Enabled]
-name=
-
-[Data Sources][NT:/SmartDashboard/Joystick Y]
-name=
-
 [Data Sources][NT:/LiveWindow/Ungrouped/PowerDistributionPanel[0]/Chan8]
-name=
-
-[Data Sources][NT:/SmartDashboard/Joystick X]
-name=
-
-[Data Sources][NT:/LiveWindow/Ungrouped/PowerDistributionPanel[0]/Chan7]
-name=
-
-[Data Sources][Joystick[0] Axis[1]]
-name=
-
-[Data Sources][NT:/FMSInfo/StationNumber]
-name=
-
-[Data Sources][NT:/Shuffleboard/Battery/Battery Voltage2]
-name=
-
-[Data Sources][Y Accel[0]]
-name=
-
-[Data Sources][NT:/SmartDashboard/DB/Button 1]
 name=
 
 [Data Sources][NT:/LiveWindow/Ungrouped/PowerDistributionPanel[0]/Chan9]
 name=
 
-[Data Sources][FMS:MatchTime]
-name=
-
-[Data Sources][NT:/SmartDashboard/DB/Button 0]
-name=
-
-[Data Sources][Joystick[0] Button[4]]
-name=
-
-[Data Sources][Joystick[0] Button[15]]
-name=
-
-[Data Sources][NT:/SmartDashboard/DB/Button 3]
-name=
-
-[Data Sources][NT:/SmartDashboard/Dial]
-name=
-
-[Data Sources][Joystick[0] Button[8]]
-name=
-
-[Data Sources][NT:/SmartDashboard/Battery Voltage]
-name=
-
-[Data Sources][NT:/Shuffleboard/Battery/Battery Voltage]
-name=
-
-[Data Sources][NT:/LiveWindow/print/.hasCommand]
-name=
-
-[Data Sources][NT:/SmartDashboard/DB/Button 2]
+[Data Sources][NT:/LiveWindow/Ungrouped/PowerDistributionPanel[0]/Chan7]
 name=
 
 [Data Sources][NT:/Usage/Client/Dashboard/UpdatesPS]
 name=
 
+[Data Sources][Joystick[1] Button[15]]
+name=
+
+[Data Sources][NT:/LiveWindow/Ungrouped/PIDController[2]/p]
+name=
+
+[Data Sources][NT:/FMSInfo/StationNumber]
+name=
+
+[Data Sources][NT:/Shuffleboard/Drive/Forward Lock Toggle]
+name=
+
+[Data Sources][NT:/LiveWindow/Ungrouped/DifferentialDrive[1]/.actuator]
+name=
+
+[Data Sources][NT:/LiveWindow/Ungrouped/PIDController[2]/setpoint]
+name=
+
+[Data Sources][FMS:MatchTime]
+name=
+
+[Data Sources][NT:/LiveWindow/Ungrouped/PIDController[2]/d]
+name=
+
+[Data Sources][Joystick[1] Button[1]]
+name=
+
+[Data Sources][Joystick[0] Button[4]]
+name=
+
+[Data Sources][NT:/LiveWindow/Ungrouped/PIDController[2]/i]
+name=
+
+[Data Sources][NT:/SmartDashboard/Dial]
+name=
+
+[Data Sources][Joystick[1] Button[9]]
+name=
+
+[Data Sources][navX-Sensor[0]-Yaw]
+name=
+
 [Data Sources][Joystick[0] Button[12]]
 name=
 
-[Data Sources][NT:/LiveWindow/Ungrouped/PowerDistributionPanel[0]/Voltage]
-name=
-
-[Data Sources][NT:/Usage/Client/Dashboard/Writes]
-name=
-
-[Data Sources][Joystick[0] Button[16]]
+[Data Sources][Joystick[1] Button[16]]
 name=
 
 [Data Sources][NT:/LiveWindow/ExampleSubsystem/.hasCommand]
@@ -207,61 +451,40 @@ name=
 [Data Sources][Joystick[0] POV[0]]
 name=
 
-[Data Sources][Joystick[0] Axis[2]]
+[Data Sources][Joystick[1] POV[0]]
 name=
 
 [Data Sources][NT:/Usage/Client/Dashboard/KBytes Transmitted]
 name=
 
-[Data Sources][Z Accel[0]]
+[Data Sources][NT:/LiveWindow/Ungrouped/Talon SRX [1]/Value]
 name=
 
 [Data Sources][NT:/FMSInfo/MatchType]
 name=
 
-[Data Sources][Joystick[0] Button[1]]
-name=
-
-[Data Sources][FMS:AutonomousMode]
+[Data Sources][Joystick[1] Button[2]]
 name=
 
 [Data Sources][Joystick[0] Button[5]]
 name=
 
-[Data Sources][NT:/FMSInfo/MatchNumber]
-name=
-
 [Data Sources][FMS:FMSAttached]
-name=
-
-[Data Sources][Joystick[0] Button[9]]
 name=
 
 [Data Sources][NT:/Usage/Client/Dashboard/ReadsPS]
 name=
 
-[Data Sources][NT:/SmartDashboard/E-Stop]
-name=
-
-[Data Sources][FMS:AllianceStationID]
-name=
-
 [Data Sources][Joystick[0] Button[13]]
 name=
 
-[Data Sources][FMS:RobotEnabled]
-name=
-
-[Data Sources][Joystick[0] Button[17]]
+[Data Sources][navX-Sensor[0]-Roll]
 name=
 
 [Data Sources][FMS:DSAttached]
 name=
 
-[Data Sources][NT:/Usage/Client/Dashboard/WritesPS]
-name=
-
-[Data Sources][Joystick[0] Axis[3]]
+[Data Sources][Joystick[1] Button[17]]
 name=
 
 [Data Sources][NT:/LiveWindow/Ungrouped/PowerDistributionPanel[0]/Chan10]
@@ -279,10 +502,13 @@ name=
 [Data Sources][NT:/LiveWindow/Ungrouped/PowerDistributionPanel[0]/Chan14]
 name=
 
-[Data Sources][Joystick[0] Button[2]]
+[Data Sources][NT:/LiveWindow/Ungrouped/PowerDistributionPanel[0]/Chan15]
 name=
 
-[Data Sources][NT:/LiveWindow/Ungrouped/PowerDistributionPanel[0]/Chan15]
+[Data Sources][NT:/SmartDashboard/Bat. Temperature]
+name=
+
+[Data Sources][Joystick[1] Button[3]]
 name=
 
 [Data Sources][NT:/SmartDashboard/Disabled]
@@ -294,64 +520,34 @@ name=
 [Data Sources][Joystick[0] Button[6]]
 name=
 
-[Data Sources][NT:/Usage/Client/Dashboard/Reads]
-name=
-
-[Data Sources][FMS:TestMode]
+[Data Sources][NT:/SmartDashboard/Joystick 1 Y]
 name=
 
 [Data Sources][NT:/LiveWindow/Ungrouped/PowerDistributionPanel[0]/TotalCurrent]
 name=
 
-[Data Sources][NT:/Usage/Client/Dashboard/Updates]
+[Data Sources][NT:/SmartDashboard/Joystick 1 X]
 name=
 
-[Data Sources][FMS:EStop]
-name=
-
-[Data Sources][Joystick[0] Button[10]]
-name=
-
-[Data Sources][NT:/LiveWindow/print/.hasDefault]
-name=
-
-[Data Sources][NT:/SmartDashboard/Bat. Temperature]
+[Data Sources][Joystick[1] Button[10]]
 name=
 
 [Data Sources][Joystick[0] Button[14]]
 name=
 
-[Data Sources][NT:/SmartDashboard/DB/Slider 1]
-name=
-
-[Data Sources][NT:/SmartDashboard/DB/Slider 0]
-name=
-
 [Data Sources][Joystick[0] Axis[0]]
 name=
 
-[Data Sources][NT:/SmartDashboard/DB/Slider 2]
-name=
-
-[Data Sources][NT:/SmartDashboard/Total Energy]
+[Data Sources][NT:/Shuffleboard/Drive/Forward Lock]
 name=
 
 [Data Sources][X Accel[0]]
 name=
 
-[Data Sources][NT:/SmartDashboard/DB/Slider 3]
-name=
-
 [Data Sources][NT:/LiveWindow/ExampleSubsystem/.hasDefault]
 name=
 
-[Data Sources][NT:/FMSInfo/IsRedAlliance]
-name=
-
 [Data Sources][NT:/Usage/Client/Dashboard/Count]
-name=
-
-[Data Sources][Joystick[0] Button[3]]
 name=
 
 [SimWindow][Mechanism 2D]
@@ -383,8 +579,32 @@ name=Subsystem
 [NTProvider][/LiveWindow/print]
 name=Subsystem
 
+[NTProvider][/SmartDashboard/Field]
+name=Field2d
+
+[NTProvider][/LiveWindow/Ungrouped/Talon SRX [3]]
+name=Speed Controller
+
+[NTProvider][/LiveWindow/Ungrouped/navX-Sensor]
+name=Gyro
+
+[NTProvider][/LiveWindow/Ungrouped/PIDController[2]]
+name=PIDController
+
+[NTProvider][/LiveWindow/Ungrouped/PIDController[1]]
+name=PIDController
+
+[NTProvider][/LiveWindow/Ungrouped/Talon SRX [1]]
+name=Speed Controller
+
 [NTProvider][/LiveWindow/Ungrouped/Scheduler]
 name=Scheduler
+
+[NTProvider][/LiveWindow/Ungrouped/DifferentialDrive[1]]
+name=DifferentialDrive
+
+[NTProvider][/LiveWindow/DriveTrain]
+name=Subsystem
 
 [DSManager][FMS]
 name=

--- a/shuffleboard config/shuffleboard.json
+++ b/shuffleboard config/shuffleboard.json
@@ -1,7 +1,7 @@
 {
   "tabPane": [
     {
-      "title": "SmartDashboard",
+      "title": "Drive",
       "autoPopulate": true,
       "autoPopulatePrefix": "SmartDashboard/",
       "widgetPane": {
@@ -10,76 +10,7 @@
         "hgap": 16.0,
         "vgap": 16.0,
         "tiles": {
-          "0,0": {
-            "size": [
-              1,
-              1
-            ],
-            "content": {
-              "_type": "Number Bar",
-              "_source0": "network_table:///SmartDashboard/Joystick X",
-              "_title": "Joystick X",
-              "Range/Min": -1.0,
-              "Range/Max": 1.0,
-              "Range/Center": 0.0,
-              "Visuals/Num tick marks": 5,
-              "Visuals/Show text": true
-            }
-          },
-          "1,0": {
-            "size": [
-              1,
-              1
-            ],
-            "content": {
-              "_type": "Number Bar",
-              "_source0": "network_table:///SmartDashboard/Joystick Y",
-              "_title": "Joystick Y",
-              "Range/Min": -1.0,
-              "Range/Max": 1.0,
-              "Range/Center": 0.0,
-              "Visuals/Num tick marks": 5,
-              "Visuals/Show text": true
-            }
-          },
-          "2,0": {
-            "size": [
-              1,
-              1
-            ],
-            "content": {
-              "_type": "Simple Dial",
-              "_source0": "network_table:///SmartDashboard/Dial",
-              "_title": "Dial",
-              "Range/Min": -1.0,
-              "Range/Max": 1.0,
-              "Visuals/Show value": true
-            }
-          },
-          "0,2": {
-            "size": [
-              3,
-              2
-            ],
-            "content": {
-              "_type": "PDP",
-              "_source0": "network_table:///LiveWindow/Ungrouped/PowerDistributionPanel[0]",
-              "_title": "LiveWindow/Ungrouped/PowerDistributionPanel[0]",
-              "Visuals/Show voltage and current values": true
-            }
-          },
-          "3,2": {
-            "size": [
-              1,
-              1
-            ],
-            "content": {
-              "_type": "Text View",
-              "_source0": "network_table:///SmartDashboard/Total Energy",
-              "_title": "Total Energy"
-            }
-          },
-          "3,0": {
+          "5,3": {
             "size": [
               1,
               1
@@ -92,29 +23,7 @@
               "Colors/Color when false": "#8B0000FF"
             }
           },
-          "3,3": {
-            "size": [
-              1,
-              1
-            ],
-            "content": {
-              "_type": "Text View",
-              "_source0": "network_table:///SmartDashboard/Bat. Temperature",
-              "_title": "Bat. Temperature"
-            }
-          },
-          "4,0": {
-            "size": [
-              1,
-              1
-            ],
-            "content": {
-              "_type": "Text View",
-              "_source0": "network_table:///SmartDashboard/Joystick Z",
-              "_title": "Joystick Z"
-            }
-          },
-          "5,0": {
+          "5,4": {
             "size": [
               1,
               1
@@ -125,15 +34,99 @@
               "_title": "Distance"
             }
           },
-          "6,0": {
+          "0,0": {
             "size": [
               1,
               1
             ],
             "content": {
               "_type": "Text View",
-              "_source0": "network_table:///SmartDashboard/Gyro",
-              "_title": "Gyro"
+              "_source0": "network_table:///SmartDashboard/Joystick 1 X",
+              "_title": "Joystick 1 X"
+            }
+          },
+          "1,0": {
+            "size": [
+              1,
+              1
+            ],
+            "content": {
+              "_type": "Text View",
+              "_source0": "network_table:///SmartDashboard/Joystick 1 Y",
+              "_title": "Joystick 1 Y"
+            }
+          },
+          "0,1": {
+            "size": [
+              1,
+              1
+            ],
+            "content": {
+              "_type": "Text View",
+              "_source0": "network_table:///SmartDashboard/Joystick 2 X",
+              "_title": "Joystick 2 X"
+            }
+          },
+          "1,1": {
+            "size": [
+              1,
+              1
+            ],
+            "content": {
+              "_type": "Text View",
+              "_source0": "network_table:///SmartDashboard/Joystick 2 Y",
+              "_title": "Joystick 2 Y"
+            }
+          },
+          "3,3": {
+            "size": [
+              2,
+              2
+            ],
+            "content": {
+              "_type": "Gyro",
+              "_source0": "network_table:///LiveWindow/Ungrouped/navX-Sensor",
+              "_title": "/LiveWindow/Ungrouped/navX-Sensor",
+              "Visuals/Major tick spacing": 45.0,
+              "Visuals/Starting angle": 180.0,
+              "Visuals/Show tick mark ring": true,
+              "Visuals/Counter clockwise": false
+            }
+          },
+          "0,3": {
+            "size": [
+              3,
+              2
+            ],
+            "content": {
+              "_type": "Differential Drivebase",
+              "_source0": "network_table:///LiveWindow/Ungrouped/DifferentialDrive[1]",
+              "_title": "DifferentialDrive[1]",
+              "Wheels/Number of wheels": 6,
+              "Wheels/Wheel diameter": 43.0,
+              "Visuals/Show velocity vectors": true
+            }
+          },
+          "6,2": {
+            "size": [
+              3,
+              3
+            ],
+            "content": {
+              "_type": "Grid Layout",
+              "_title": "Driver Assist Status",
+              "Layout/Number of columns": 3,
+              "Layout/Number of rows": 3,
+              "Layout/Label position": "BOTTOM",
+              "_children": {
+                "0,0": {
+                  "_type": "Boolean Box",
+                  "_source0": "network_table:///SmartDashboard/Forward Lock",
+                  "_title": "Forward Snapping",
+                  "Colors/Color when true": "#7CFC00FF",
+                  "Colors/Color when false": "#8B0000FF"
+                }
+              }
             }
           }
         }
@@ -167,49 +160,45 @@
                   "Visuals/Show voltage and current values": true
                 },
                 {
-                  "_type": "Gyro",
-                  "_source0": "network_table:///LiveWindow/Ungrouped/navX-Sensor",
-                  "_title": "navX-Sensor",
-                  "Visuals/Major tick spacing": 45.0,
-                  "Visuals/Starting angle": 180.0,
-                  "Visuals/Show tick mark ring": true,
-                  "Visuals/Counter clockwise": false
-                },
-                {
-                  "_type": "Differential Drivebase",
-                  "_source0": "network_table:///LiveWindow/Ungrouped/DifferentialDrive[1]",
-                  "_title": "DifferentialDrive[1]",
-                  "Wheels/Number of wheels": 4,
-                  "Wheels/Wheel diameter": 80.0,
-                  "Visuals/Show velocity vectors": true
-                },
-                {
-                  "_type": "PID Controller",
-                  "_source0": "network_table:///LiveWindow/Ungrouped/PIDController[2]",
-                  "_title": "PIDController[2]"
-                },
-                {
                   "_type": "Speed Controller",
                   "_source0": "network_table:///LiveWindow/Ungrouped/Talon SRX [3]",
-                  "_title": "Talon SRX [3]",
+                  "_title": "/LiveWindow/Ungrouped/Talon SRX [3]",
                   "Visuals/Orientation": "HORIZONTAL"
                 },
                 {
                   "_type": "Speed Controller",
                   "_source0": "network_table:///LiveWindow/Ungrouped/Talon SRX [1]",
-                  "_title": "Talon SRX [1]",
+                  "_title": "/LiveWindow/Ungrouped/Talon SRX [1]",
                   "Visuals/Orientation": "HORIZONTAL"
                 },
                 {
                   "_type": "PID Controller",
                   "_source0": "network_table:///LiveWindow/Ungrouped/PIDController[1]",
-                  "_title": "PIDController[1]"
+                  "_title": "/LiveWindow/Ungrouped/PIDController[1]"
                 },
                 {
-                  "_type": "PDP",
-                  "_source0": "network_table:///LiveWindow/Ungrouped/PowerDistributionPanel[1]",
-                  "_title": "PowerDistributionPanel[1]",
-                  "Visuals/Show voltage and current values": true
+                  "_type": "PID Controller",
+                  "_source0": "network_table:///LiveWindow/Ungrouped/PIDController[2]",
+                  "_title": "/LiveWindow/Ungrouped/PIDController[2]"
+                },
+                {
+                  "_type": "Text View",
+                  "_source0": "network_table:///LiveWindow/Ungrouped/DifferentialDrive[1]/Left Motor Speed",
+                  "_title": "LiveWindow/Ungrouped/DifferentialDrive[1]/Left Motor Speed"
+                },
+                {
+                  "_type": "Text View",
+                  "_source0": "network_table:///LiveWindow/Ungrouped/DifferentialDrive[1]/Right Motor Speed",
+                  "_title": "LiveWindow/Ungrouped/DifferentialDrive[1]/Right Motor Speed"
+                },
+                {
+                  "_type": "Gyro",
+                  "_source0": "network_table:///LiveWindow/Ungrouped/navX-Sensor",
+                  "_title": "LiveWindow/Ungrouped/navX-Sensor",
+                  "Visuals/Major tick spacing": 45.0,
+                  "Visuals/Starting angle": 180.0,
+                  "Visuals/Show tick mark ring": true,
+                  "Visuals/Counter clockwise": false
                 }
               ]
             }
@@ -234,6 +223,19 @@
             ],
             "content": {
               "_type": "Subsystem Layout",
+              "_source0": "network_table:///LiveWindow/EStopSS",
+              "_title": "EStopSS",
+              "Layout/Label position": "BOTTOM",
+              "_children": []
+            }
+          },
+          "6,0": {
+            "size": [
+              2,
+              4
+            ],
+            "content": {
+              "_type": "Subsystem Layout",
               "_source0": "network_table:///LiveWindow/DriveTrain",
               "_title": "DriveTrain",
               "Layout/Label position": "BOTTOM",
@@ -247,7 +249,7 @@
   "windowGeometry": {
     "x": -8.0,
     "y": -8.0,
-    "width": 1616.0,
-    "height": 876.0
+    "width": 1936.0,
+    "height": 1048.0
   }
 }

--- a/src/main/java/frc/robot/Robot.java
+++ b/src/main/java/frc/robot/Robot.java
@@ -63,13 +63,16 @@ public class Robot extends TimedRobot
 
 
         Joystick joystick = robotContainer.getJoystick();
+        Joystick joystickTwo = robotContainer.getJoystickTwo();
 
         PowerDistributionPanel pdp = robotContainer.getPDP();
         
         // Shuffleboard setup
-        SmartDashboard.putNumber("Joystick X", joystick.getX());
-        SmartDashboard.putNumber("Joystick Y", joystick.getY());
-        SmartDashboard.putNumber("Joystick Z", joystick.getZ());
+        SmartDashboard.putNumber("Joystick 1 X", joystick.getX());
+        SmartDashboard.putNumber("Joystick 1 Y", joystick.getY());
+
+        SmartDashboard.putNumber("Joystick 2 X", joystickTwo.getX());
+        SmartDashboard.putNumber("Joystick 2 Y", joystickTwo.getY());
     }
 
 

--- a/src/main/java/frc/robot/RobotContainer.java
+++ b/src/main/java/frc/robot/RobotContainer.java
@@ -50,6 +50,7 @@ public class RobotContainer {
 
         // Put initial booleans
         SmartDashboard.putBoolean("E-Stop", Constants.EStop);
+        SmartDashboard.putBoolean("Forward Lock", false);
 
         configureButtonBindings();
     }
@@ -82,6 +83,10 @@ public class RobotContainer {
 
     public Joystick getJoystick() {
         return joystick;
+    }
+
+    public Joystick getJoystickTwo() {
+        return joystickTwo;
     }
 
     public PowerDistributionPanel getPDP() {

--- a/src/main/java/frc/robot/commands/DriveCommand.java
+++ b/src/main/java/frc/robot/commands/DriveCommand.java
@@ -37,8 +37,8 @@ public class DriveCommand extends CommandBase {
     addRequirements(drive);
 
     // Creates a SlewRateLimiter that limits the rate of change of the signal to 0.5 units per second
-    filterLeft = new SlewRateLimiter(5);
-    filterRight = new SlewRateLimiter(5);
+    filterLeft = new SlewRateLimiter(3);
+    filterRight = new SlewRateLimiter(3);
   }
 
   // Called when the command is initially scheduled.

--- a/src/main/java/frc/robot/util/ShuffleboardManager.java
+++ b/src/main/java/frc/robot/util/ShuffleboardManager.java
@@ -1,0 +1,104 @@
+package frc.robot.util;
+
+import edu.wpi.first.networktables.NetworkTableEntry;
+import edu.wpi.first.wpilibj.shuffleboard.Shuffleboard;
+import edu.wpi.first.wpilibj.shuffleboard.ShuffleboardComponent;
+import edu.wpi.first.wpilibj.shuffleboard.ShuffleboardTab;
+
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.Map;
+import java.util.Set;
+
+public class ShuffleboardManager {
+    private static ShuffleboardManager defaultInstance = null;
+
+
+    public static ShuffleboardManager getInstance() {
+        if (defaultInstance == null) {
+            defaultInstance = new ShuffleboardManager();
+        }
+        return defaultInstance;
+    }
+    public NetworkTableEntry slewLimit;
+    public NetworkTableEntry forwardSnapping;
+    private ShuffleboardTab shuffleTab;
+
+    public ShuffleboardManager() {
+        /* This is how to declare HashMap */
+        HashMap<Integer, String> hmap = new HashMap<Integer, String>();
+        hmap.put(12, "Cool");
+        hmap.put(2, "Beans");
+        hmap.put(7, "This");
+        hmap.put(49, "is");
+        hmap.put(3, "Amazing");
+
+        Set set = hmap.entrySet();
+        for (Object o : set) {
+            Map.Entry mentry = (Map.Entry) o;
+            System.out.print("key is: " + mentry.getKey() + " & Value is: ");
+            System.out.println(mentry.getValue());
+        }
+
+        /* Get values based on key*/
+        String var= hmap.get(2);
+        System.out.println("Value at index 2 is: "+var);
+
+        /* Remove values based on key*/
+        hmap.remove(3);
+        System.out.println("Map key and values3 after removal:");
+        Set set2 = hmap.entrySet();
+        Iterator iterator2 = set2.iterator();
+        while(iterator2.hasNext()) {
+            Map.Entry mentry2 = (Map.Entry) iterator2.next();
+            System.out.print("Key is: " + mentry2.getKey() + " & Value is: ");
+            System.out.println(mentry2.getValue());
+        }
+
+
+
+        /*SlewRateLimiter filter = new SlewRateLimiter(0.5);
+    filter.calculate(input);
+    */
+
+        //SmartDashboard.putBoolean("Driving Reverse", xbox.getBButtonPressed());
+        //SmartDashboard.putNumber("Slew Limit", joystickChangeLimit);
+        /**Below are the updated versions of above **/
+        slewLimit = Shuffleboard.getTab("Driver Assist")
+                .add("Slew Limit", true)
+                .withWidget("Toggle Button")
+                .getEntry();
+
+        forwardSnapping = Shuffleboard.getTab("Driver Assist")
+                .add("Forward Snapping", false)
+                .withWidget("Toggle Button")
+                .getEntry();
+
+        forwardSnapping.setBoolean(true);
+
+    }
+
+
+    public void setForwardSnapping(boolean value) {
+        forwardSnapping.setBoolean(value);
+    }
+
+    public boolean getForwardSnapping() {
+        return forwardSnapping.getBoolean(false);
+    }
+
+    public void setSlewLimit(boolean value) {
+        slewLimit.setBoolean(value);
+    }
+
+    public boolean getSlewLimit() {
+        return slewLimit.getBoolean(false);
+    }
+
+    public void CreateWidget(String name) {
+        for (ShuffleboardComponent widgetComponent : shuffleTab.getComponents()) {
+            if (widgetComponent.getTitle().equals(name)) {
+            }
+        }
+    }
+}


### PR DESCRIPTION
Add Drive Assist Features:
     - Forward Snapping (If joysticks are within 15% of each other, they snap to each other for more accurate forwards)
     - SlewRateLimiter (Slows/smoothes changes between joystick movements, helps motor life)
Updated Shuffleboard to contain options for the new drive assist features
Rearranged shuffleboard format and added drive assist tab
Added drive curves back from arcade drive to tank drive

Curves may have to be tweaked because of the change to tank